### PR TITLE
Fix SMS Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ func main() {
 
 	client := nexmo.NewClient(http.DefaultClient, auth)
 	smsReq := nexmo.SendSMSRequest {
-	    From = FROM_NUMBER,
-	    To = TO_NUMBER,
-	    Text = "This message comes to you from Nexmo via Golang",
+	    From: FROM_NUMBER,
+	    To: TO_NUMBER,
+	    Text: "This message comes to you from Nexmo via Golang",
     }
 
 	callR, _, err := client.SMS.SendSMS(smsReq)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println("%+v", callR)
+	fmt.Println("Status:", callR.Messages[0].Status)
 }
 ```
 


### PR DESCRIPTION
The SMS example was using the = sign to pair key values in the SendSMSRequest struct which causes errors. Amended to use the colon symbol instead.