### PR TITLE
Add workflow id parameter on Verify Request

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -16,6 +16,7 @@ type StartVerificationRequest struct {
 	RequireType   string `json:"require_type,omitempty"`
 	PINExpiry     int16  `json:"pin_expiry,omitempty"`
 	NextEventWait int16  `json:"next_event_wait,omitempty"`
+	WorkflowID    int8   `json:"workflow_id,omitempty"`
 }
 
 type StartVerificationResponse struct {

--- a/verify_base.go
+++ b/verify_base.go
@@ -16,6 +16,6 @@ func newVerifyService(base *sling.Sling, authSet *AuthSet) *VerifyService {
 	}
 }
 
-func (c *VerifyService) SetBaseURL(baseURL string) {
-	c.sling.Base(baseURL)
+func (s *VerifyService) SetBaseURL(baseURL string) {
+	s.sling.Base(baseURL)
 }


### PR DESCRIPTION
This PR fixes issue https://github.com/nexmo-community/nexmo-go/issues/24 and adds the `workflow_id` parameter to the `StartVerificationRequest`.